### PR TITLE
days alive pings should be while alive not just at startup shudown.

### DIFF
--- a/driver-addon/README.md
+++ b/driver-addon/README.md
@@ -3,18 +3,7 @@
 ## Use:
 
 ```
-# cd x-addon, build the addon.
-```
-
-```
-# 2.  here.
-npm install
-
-cp ../x-addon/*xpi .
-
-# serve at localhost:3555
-npm run serve &
-
+npm run serve
 npm run test
 ```
 

--- a/driver-addon/package.json
+++ b/driver-addon/package.json
@@ -14,7 +14,7 @@
     "jetpack"
   ],
   "scripts": {
-    "pretest": "bash pretest.sh && npm run serve",
+    "pretest": "bash pretest.sh",
     "test":  "jpm test",
     "serve": "curl -s -I localhost:3555 &> /dev/null || serve -p 3555 ."
   },

--- a/driver-addon/prefs.json
+++ b/driver-addon/prefs.json
@@ -1,0 +1,3 @@
+{
+  "extensions.@x-screen-draw-performance-shield-study-1.firstrun": 500
+}

--- a/driver-addon/prefs2.json
+++ b/driver-addon/prefs2.json
@@ -1,0 +1,3 @@
+{
+  "nglayout.initialpaint.delay": 13
+}

--- a/driver-addon/test/test-x-addon-end-to-end.js
+++ b/driver-addon/test/test-x-addon-end-to-end.js
@@ -18,22 +18,23 @@ prefSvc.set("xpinstall.signatures.required",false);
 prefSvc.set("xpinstall.whitelist.required",false);
 
 // specific to this experiment... needs npm run serve
-const addonUrl = "http://localhost:3555/x-screen-draw-performance-variations-1.xpi";
+const addonUrl = "http://localhost:3555/x-screen-draw-performance-shield-study-1.xpi";
 
-const addonId = "@x-screen-draw-performance-variations-1";
+const addonId = "@x-screen-draw-performance-shield-study-1";
 const PAINTPREF = 'nglayout.initialpaint.delay';
 
 function getAddonPref (name) {
-  return prefSvc.get("extensions.@x-screen-draw-performance-variations-1." + name);
+  return prefSvc.get("extensions.@x-screen-draw-performance-shield-study-1." + name);
 }
 
 function setAddonPref (name, val) {
-  return prefSvc.set("extensions.@x-screen-draw-performance-variations-1." + name, val);
+  console.log("setting:", name, val);
+  return prefSvc.set("extensions.@x-screen-draw-performance-shield-study-1." + name, val);
 }
 
 function resetPrefs () {
   prefSvc.reset(PAINTPREF);
-  console.log('reset pref!');
+  console.log('reset pref!', PAINTPREF);
 }
 
 function installAddon() {
@@ -193,10 +194,11 @@ exports['test 4: end-of-study'] = function (assert, done) {
   setAddonPref("firstrun", 500);
 
   // 3.  install the addon
-  installAddon().then(waitABit).then(
+  installAddon().then(waitABit).then(waitABit).then(
   hasAddon).then(
     // Expect
     (addonThere) => {
+      console.log(`there: ${addonThere}`,getAddonPref("firstrun"),getAddonPref("variation"), prefSvc.get(PAINTPREF),hasTabWithUrlLike(/qsurvey/))
       // 1. addon will briefly install.
       // 2. addon will die (`about:addons` will no longer show it)
       expect(addonThere).to.be.false;

--- a/x-addon/package.json
+++ b/x-addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "x-screen-draw-performance-shield-study-1",
   "name": "x-screen-draw-performance-shield-study-1",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Mozilla Screen Draw Performance Enhancements Study.",
   "main": "src/index.js",
   "author": "Gregg Lind <glind@mozilla.com>",

--- a/x-addon/src/index.js
+++ b/x-addon/src/index.js
@@ -10,9 +10,10 @@ const forSetup = {
 };
 
 function main (options, callback) {
-  var xconfig = xutils.xsetup(forSetup);  // call first.
-  xutils.handleStartup(options, xconfig, variationsMod);
-
+  xutils.generateTelemetryIdIfNeeded().then(function () {
+    var xconfig = xutils.xsetup(forSetup);  // call first.
+    xutils.handleStartup(options, xconfig, variationsMod);
+  })
   // addon specific load code should go here, if there is additional.
 }
 

--- a/x-addon/src/variations.js
+++ b/x-addon/src/variations.js
@@ -10,10 +10,12 @@ const variations = {
   'medium':  function () {
     prefSvc.set(PAINTPREF,50);
   },
-  'weak':  function () {
-    prefSvc.set(PAINTPREF,1000);
-  },
-  'ut':  () => {}  // 230  // ut:: usual treatment
+  //'weak':  function () {
+  //  prefSvc.set(PAINTPREF,1000);
+  //},
+
+  // https://dxr.mozilla.org/mozilla-central/source/layout/base/nsPresShell.h#71
+  'ut':  () => {}  // 250  // ut:: usual treatment
 }
 
 function isEligible () {

--- a/x-addon/test/test-experimental-utils.js
+++ b/x-addon/test/test-experimental-utils.js
@@ -39,7 +39,8 @@ exports['test right keys'] = function (assert) {
     ["handleStartup", "function"],
     ["handleOnUnload", "function"],
     ["resetPrefs", "function"],
-    ["studyManager", "object"]
+    ["studyManager", "object"],
+    ["generateTelemetryIdIfNeeded", "function"]
   ];
   let keys = expected.map((x)=>x[0]);
   expect(xutils).to.have.all.keys(keys);

--- a/x-addon/test/test-variations.js
+++ b/x-addon/test/test-variations.js
@@ -38,8 +38,8 @@ exports['test variations are functions'] = function (assert) {
   }
 }
 
-exports['test there are 4 variations'] = function (assert) {
-  expect(Object.keys(variationsMod.variations).length).to.equal(4);
+exports['test there are 3 variations'] = function (assert) {
+  expect(Object.keys(variationsMod.variations).length).to.equal(3);
 }
 
 require("sdk/test").run(exports);


### PR DESCRIPTION
Needs / implies 'fuses'.

This means we undercount report rates